### PR TITLE
fix: garmany personal tin number separators removed

### DIFF
--- a/stdnum/de/idnr.py
+++ b/stdnum/de/idnr.py
@@ -53,9 +53,8 @@ from stdnum.util import clean, isdigits
 
 
 def compact(number):
-    """Convert the number to the minimal representation. This strips the
-    number of any valid separators and removes surrounding whitespace."""
-    return clean(number, ' -./,').strip()
+    """Convert the number to the minimal representation. It shouldn't have any separators."""
+    return clean(number, '').strip()
 
 
 def validate(number):

--- a/tests/test_de_idnr.doctest
+++ b/tests/test_de_idnr.doctest
@@ -32,15 +32,15 @@ start with a zero.
 >>> idnr.validate('116574261809')
 Traceback (most recent call last):
     ...
-InvalidLength: ...
+stdnum.exceptions.InvalidLength: The number has an invalid length.
 >>> idnr.validate('A6574261809')
 Traceback (most recent call last):
     ...
-InvalidFormat: ...
+stdnum.exceptions.InvalidFormat: The number has an invalid format.
 >>> idnr.validate('01234567896')
 Traceback (most recent call last):
     ...
-InvalidFormat: ...
+stdnum.exceptions.InvalidFormat: The number has an invalid format.
 
 
 The first 10 digits of the IdNr is supposed to contain exactly one digit
@@ -48,19 +48,23 @@ twice (or three times since 2016) and all other digits in the number can only
 appear once. This tries to catch some corner cases. Note that only the first
 10 digits are considered for this.
 
->>> idnr.validate('1234567890 3')  # each digit once
+>>> idnr.validate('12345678903')  # each digit once
 Traceback (most recent call last):
     ...
-InvalidFormat: ...
->>> idnr.validate('1123456789 0')  # one digit twice
+stdnum.exceptions.InvalidFormat: The number has an invalid format.
+>>> idnr.validate('11234567890')  # one digit twice
 '11234567890'
->>> idnr.validate('1112345678 6')  # one digit three times
+>>> idnr.validate('11123456786')  # one digit three times
 '11123456786'
+>>> idnr.validate('1112345678 6')  # one digit three times
+Traceback (most recent call last):
+    ...
+stdnum.exceptions.InvalidLength: The number has an invalid length.
 >>> idnr.validate('1111234567 8')  # one digit four times
 Traceback (most recent call last):
     ...
-InvalidFormat: ...
+stdnum.exceptions.InvalidLength: The number has an invalid length.
 >>> idnr.validate('1122345678 5')  # two digits more than once
 Traceback (most recent call last):
     ...
-InvalidFormat: ...
+stdnum.exceptions.InvalidLength: The number has an invalid length.


### PR DESCRIPTION
Germany personal tin number shouldn't have any separators.